### PR TITLE
Fixed a bug with the Regexp checking and a bug with force option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,10 @@ module.exports = function(options){
 		options = {};
 	}
 
+	if (options.force && typeof options.force !== 'boolean') {
+		options.force = false;
+	}
+
 	return map(function (file, cb){
 		var cwd = file.cwd || process.cwd();
 		// For safety always resolve paths


### PR DESCRIPTION
I found a couple bugs:
1. Moved to use relative path to avoid problems with backslashes in Windows path.
2. Consider everything else than {force: true} to be false. Previously for example {force: 'false'} or {force: 'anything'} was considered to be true.
