### PR TITLE
change rimraf to gulp-rimraf in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Usage
  1. Delete a folder: use [rimraf](https://github.com/isaacs/rimraf) directly *(you don't need gulp-rimraf!)*:
 
  ```javascript
- var rimraf = require('rimraf'); // rimraf directly
+ var rimraf = require('gulp-rimraf'); // rimraf directly
  gulp.task('task', function (cb) {
 	rimraf('./folder', cb);
  });


### PR DESCRIPTION
I found a wrong word in README.md, maybe `rimraf` is mean `gulp-rimraf` :)